### PR TITLE
Build as library instead of from source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,14 @@ set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.58.0 COMPONENTS program_options filesystem REQUIRED)
-INCLUDE_DIRECTORIES( ${Boost_INCLUDE_DIR} )
+INCLUDE_DIRECTORIES( ${Boost_INCLUDE_DIR} include)
 
+add_library(pcl_norm_2d src/PCA2D.cpp src/Normal2dEstimation.cpp)
+set_target_properties(pcl_norm_2d PROPERTIES PUBLIC_HEADER "include/Normal2dEstimation.h;include/PCA2D.h")
+install(TARGETS pcl_norm_2d
+  PUBLIC_HEADER DESTINATION include/pcl_normal_estimation_2d)
 
 #PointXYNormal.cpp PointXYNormal.h
-add_executable(norm_2d main.cpp include/PCA2D.h src/PCA2D.cpp include/Normal2dEstimation.h src/Normal2dEstimation.cpp)
-target_link_libraries(norm_2d ${PCL_LIBRARIES}  ${Boost_LIBRARIES})
+add_executable(norm_2d main.cpp)
+target_link_libraries(norm_2d pcl_norm_2d ${PCL_LIBRARIES}  ${Boost_LIBRARIES})
+


### PR DESCRIPTION
In order to simplify integration with other projects, build as a
library along with an executable. The library is handled as a
dependency for the executable. In addition, add an `install` target
for the libraries and headers.